### PR TITLE
Add support for submitting samples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,12 @@ configurations {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:1.0.3"
     compile "org.springframework.boot:spring-boot-starter-web:1.4.1.RELEASE"
+    compile "org.springframework.boot:spring-boot-starter-data-jpa:1.4.1.RELEASE"
     compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.7.5"
     compile "org.apache.opennlp:opennlp-tools:1.6.0"
     compile "io.springfox:springfox-swagger2:2.6.0"
+
+    runtime "org.hsqldb:hsqldb:2.3.4"
 
     testCompile "org.springframework.boot:spring-boot-starter-test:1.4.1.RELEASE"
     testCompile "org.springframework.restdocs:spring-restdocs-mockmvc:1.1.2.RELEASE"

--- a/src/main/kotlin/nl/fizzylogic/intentify/controllers/DetectionController.kt
+++ b/src/main/kotlin/nl/fizzylogic/intentify/controllers/DetectionController.kt
@@ -1,6 +1,6 @@
 package nl.fizzylogic.intentify.controllers
 
-import nl.fizzylogic.intentify.forms.DetectionForm
+import nl.fizzylogic.intentify.entities.DetectionForm
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.BindingResult

--- a/src/main/kotlin/nl/fizzylogic/intentify/controllers/SamplesController.kt
+++ b/src/main/kotlin/nl/fizzylogic/intentify/controllers/SamplesController.kt
@@ -1,7 +1,11 @@
 package nl.fizzylogic.intentify.controllers
 
-import nl.fizzylogic.intentify.forms.SubmitSampleForm
-import nl.fizzylogic.intentify.forms.UpdateSampleForm
+import nl.fizzylogic.intentify.entities.ValidationError
+import nl.fizzylogic.intentify.entities.SubmitSampleForm
+import nl.fizzylogic.intentify.entities.TrainingSample
+import nl.fizzylogic.intentify.entities.UpdateSampleForm
+import nl.fizzylogic.intentify.repositories.TrainingSampleRepository
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.BindingResult
@@ -16,7 +20,7 @@ import javax.validation.Valid
  * Endpoint for submitting samples
  */
 @RestController
-class SamplesController {
+class SamplesController @Autowired() constructor(private val trainingSampleRepository: TrainingSampleRepository) {
     /**
      * Submits a new sample to the service for training
      */
@@ -27,7 +31,14 @@ class SamplesController {
         produces = arrayOf("application/json")
     )
     fun submitSample(@RequestBody @Valid form: SubmitSampleForm, bindingResult: BindingResult): ResponseEntity<*> {
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build()
+        if (bindingResult.hasErrors()) {
+            return ResponseEntity.badRequest().body(ValidationError(bindingResult.fieldErrors))
+        }
+
+        trainingSampleRepository.save(
+            TrainingSample(form.intent!!, form.text!!))
+
+        return ResponseEntity.accepted().build()
     }
 
     /**

--- a/src/main/kotlin/nl/fizzylogic/intentify/entities/DetectionForm.kt
+++ b/src/main/kotlin/nl/fizzylogic/intentify/entities/DetectionForm.kt
@@ -1,4 +1,4 @@
-package nl.fizzylogic.intentify.forms
+package nl.fizzylogic.intentify.entities
 
 import javax.validation.constraints.NotNull
 

--- a/src/main/kotlin/nl/fizzylogic/intentify/entities/FieldErrorMessage.kt
+++ b/src/main/kotlin/nl/fizzylogic/intentify/entities/FieldErrorMessage.kt
@@ -1,0 +1,9 @@
+package nl.fizzylogic.intentify.entities
+
+/**
+ * Displays an error for a single field
+ * @param field The name of the field the error occured for
+ * @param message The error message for the field
+ */
+data class FieldErrorMessage(val field: String, val message: String) {
+}

--- a/src/main/kotlin/nl/fizzylogic/intentify/entities/SubmitSampleForm.kt
+++ b/src/main/kotlin/nl/fizzylogic/intentify/entities/SubmitSampleForm.kt
@@ -1,4 +1,4 @@
-package nl.fizzylogic.intentify.forms
+package nl.fizzylogic.intentify.entities
 
 import javax.validation.constraints.NotNull
 
@@ -10,11 +10,11 @@ data class SubmitSampleForm(
          * The text of the sentence to train
          */
         @NotNull
-        var text: String,
+        var text: String?,
 
         /**
          * Intent of the sentence
          */
         @NotNull
-        var intent: String
+        var intent: String?
 )

--- a/src/main/kotlin/nl/fizzylogic/intentify/entities/TrainingSample.kt
+++ b/src/main/kotlin/nl/fizzylogic/intentify/entities/TrainingSample.kt
@@ -1,0 +1,9 @@
+package nl.fizzylogic.intentify.entities
+
+/**
+ * The training sample for the machine learning model
+ * @param intent The intent of the sentence
+ * @param text The text of the sentence
+ */
+data class TrainingSample(var intent: String, var text: String) {
+}

--- a/src/main/kotlin/nl/fizzylogic/intentify/entities/UpdateSampleForm.kt
+++ b/src/main/kotlin/nl/fizzylogic/intentify/entities/UpdateSampleForm.kt
@@ -1,4 +1,4 @@
-package nl.fizzylogic.intentify.forms
+package nl.fizzylogic.intentify.entities
 
 import javax.validation.constraints.NotNull
 

--- a/src/main/kotlin/nl/fizzylogic/intentify/entities/ValidationError.kt
+++ b/src/main/kotlin/nl/fizzylogic/intentify/entities/ValidationError.kt
@@ -1,0 +1,23 @@
+package nl.fizzylogic.intentify.entities
+
+import org.springframework.validation.FieldError
+
+/**
+ * Represents a validation error
+ */
+class ValidationError {
+    /**
+     * Initializes a new instance of ValidationError
+     * @param allErrors The errors that were detected by the controller
+     */
+    constructor(allErrors: List<FieldError>) {
+        errors = allErrors.map { element ->
+            FieldErrorMessage(element.field, element.defaultMessage)
+        }.toList()
+    }
+
+    /**
+     * Gets the errors that occurred
+     */
+    val errors: List<FieldErrorMessage>
+}

--- a/src/main/kotlin/nl/fizzylogic/intentify/repositories/TrainingSampleRepository.kt
+++ b/src/main/kotlin/nl/fizzylogic/intentify/repositories/TrainingSampleRepository.kt
@@ -1,0 +1,12 @@
+package nl.fizzylogic.intentify.repositories
+
+import nl.fizzylogic.intentify.entities.TrainingSample
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+
+/**
+ * Repository for the training samples
+ */
+@Repository
+interface TrainingSampleRepository : CrudRepository<TrainingSample, Long> {
+}

--- a/src/test/kotlin/nl/fizzylogic/intentify/controllers/DetectionControllerTests.kt
+++ b/src/test/kotlin/nl/fizzylogic/intentify/controllers/DetectionControllerTests.kt
@@ -2,7 +2,7 @@ package nl.fizzylogic.intentify.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import nl.fizzylogic.intentify.forms.DetectionForm
+import nl.fizzylogic.intentify.entities.DetectionForm
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/nl/fizzylogic/intentify/controllers/SamplesControllerTests.kt
+++ b/src/test/kotlin/nl/fizzylogic/intentify/controllers/SamplesControllerTests.kt
@@ -2,11 +2,17 @@ package nl.fizzylogic.intentify.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import nl.fizzylogic.intentify.forms.SubmitSampleForm
+import nl.fizzylogic.intentify.entities.SubmitSampleForm
+import nl.fizzylogic.intentify.entities.TrainingSample
+import nl.fizzylogic.intentify.repositories.TrainingSampleRepository
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.any
+import org.mockito.Mockito.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
@@ -19,17 +25,31 @@ class SamplesControllerTests {
     @Autowired
     lateinit var mockMvc: MockMvc
 
+    @MockBean
+    lateinit var trainingSampleRepository: TrainingSampleRepository
+
     @Test
-    fun submitSampleReturnsNotImplemented() {
-        mockMvc.perform(submitSampleRequest("This is a sample sentence", "sample")).andExpect(MockMvcResultMatchers.status().isNotImplemented)
+    fun submitSampleReturnsOk() {
+        `when`(trainingSampleRepository.save(any(TrainingSample::class.java)))
+            .thenReturn(TrainingSample("dummy", "dummy"))
+
+        mockMvc.perform(submitSampleRequest("This is a sample sentence", "sample"))
+            .andExpect(MockMvcResultMatchers.status().isAccepted)
+
+        verify(trainingSampleRepository).save(any(TrainingSample::class.java))
     }
 
-    private fun submitSampleRequest(text: String, intent: String): MockHttpServletRequestBuilder {
+    fun submitSampleWithInvalidDataReturnsBadRequest() {
+        mockMvc.perform(submitSampleRequest(null, null))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest)
+    }
+
+    private fun submitSampleRequest(text: String?, intent: String?): MockHttpServletRequestBuilder {
         val mapper = ObjectMapper().registerModule(KotlinModule())
 
         return MockMvcRequestBuilders.post("/api/training/samples")
-                .accept("application/json")
-                .contentType("application/json")
-                .content(mapper.writeValueAsString(SubmitSampleForm(text, intent)))
+            .accept("application/json")
+            .contentType("application/json")
+            .content(mapper.writeValueAsString(SubmitSampleForm(text, intent)))
     }
 }


### PR DESCRIPTION
Adds basic support for submitting training samples to the service.
Currently doesn't do a whole lot of things, but it should include the following:

 - [x] Submitting samples
 - [ ] Resetting the training set